### PR TITLE
fix fetching resync; connect values to store

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -37,6 +37,7 @@ import {
   ForageQuanPage,
   LogPage,
   SelectedPaddockPage,
+  LoadingPage,
 } from './../screens';
 import { ROUTES } from '../utils/constants';
 import { LaunchScreen } from '../screens/AuthScreens';
@@ -228,6 +229,7 @@ const RootNavigation = () => {
   const { authenticated } = useAppSelector((state) => state.auth);
   const { id, role } = useAppSelector((state) => state.auth); // userId
   const { selectedTeam } = useAppSelector((state) => state.teams);
+  const { isDataLoaded } = useAppSelector((state) => state.sync);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -258,6 +260,12 @@ const RootNavigation = () => {
     return (
       <NavigationContainer>
         <NoTeamStackScreen />
+      </NavigationContainer>
+    );
+  } else if (!isDataLoaded) {
+    return (
+      <NavigationContainer>
+        <LoadingPage />
       </NavigationContainer>
     );
   } else {

--- a/src/redux/slices/cowCensusSlice.ts
+++ b/src/redux/slices/cowCensusSlice.ts
@@ -156,7 +156,7 @@ export const cowCensusSlice = createSlice({
         state.indices.byTag[cowCensus.tag] = cowCensus;
       });
       if (cowCensuses.length > 0) {
-        state.indices.latest = cowCensuses.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+        state.indices.latest = cowCensuses.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
       }
     });
     builder.addCase(createCowCensus.fulfilled, (state, action) => {
@@ -186,7 +186,7 @@ export const cowCensusSlice = createSlice({
       if (state.indices.latest && cowCensus.id === state.indices.latest.id) {
         delete state.indices.latest;
         if (Object.values(state.all).length > 0) {
-          state.indices.latest = Object.values(state.all).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+          state.indices.latest = Object.values(state.all).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
         }
       }
       alert('Deleted cowCensus!');

--- a/src/redux/slices/dungCensusSlice.ts
+++ b/src/redux/slices/dungCensusSlice.ts
@@ -143,7 +143,7 @@ export const dungCensusSlice = createSlice({
         state.all[dungCensus.id] = dungCensus;
       });
       if (dungCensuses.length > 0) {
-        state.indices.latest = dungCensuses.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+        state.indices.latest = dungCensuses.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
       }
     });
     builder.addCase(createDungCensus.fulfilled, (state, action) => {
@@ -169,7 +169,7 @@ export const dungCensusSlice = createSlice({
       if (state.indices.latest && dungCensus.id === state.indices.latest.id) {
         delete state.indices.latest;
         if (Object.values(state.all).length > 0) {
-          state.indices.latest = Object.values(state.all).sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+          state.indices.latest = Object.values(state.all).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
         }
       }
       alert('Deleted dungCensus!');

--- a/src/redux/slices/forageQualityCensusSlice.ts
+++ b/src/redux/slices/forageQualityCensusSlice.ts
@@ -15,11 +15,13 @@ export interface IForageQualityCensus {
 export interface ForageQualityCensusState {
   loading: boolean
   all: Record<string, IForageQualityCensus>
+  byPlot: Record<string, IForageQualityCensus[]>
 }
 
 const initialState: ForageQualityCensusState = {
   loading: false,
   all: {},
+  byPlot: {},
 };
 
 export const getForageQualityCensusesByPlotId = createAsyncThunk(
@@ -132,26 +134,49 @@ export const forageQualityCensusSlice = createSlice({
       const forageQualityCensuses: IForageQualityCensus[] = action.payload as IForageQualityCensus[];
       forageQualityCensuses.forEach((forageQualityCensus: IForageQualityCensus) => {
         state.all[forageQualityCensus.id] = forageQualityCensus;
+        if (!state.byPlot[forageQualityCensus.plotId]) {
+          state.byPlot[forageQualityCensus.plotId] = [];
+        }
+        state.byPlot[forageQualityCensus.plotId].push(forageQualityCensus);
+      });
+      Object.keys(state.byPlot).forEach((plotId: string) => {
+        state.byPlot[plotId] = state.byPlot[plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       });
     });
     builder.addCase(createForageQualityCensus.fulfilled, (state, action) => {
       const forageQualityCensus: IForageQualityCensus = action.payload as IForageQualityCensus;
       state.all[forageQualityCensus.id] = forageQualityCensus;
+      if (!state.byPlot[forageQualityCensus.plotId]) {
+        state.byPlot[forageQualityCensus.plotId] = [];
+      }
+      state.byPlot[forageQualityCensus.plotId].push(forageQualityCensus);
+      state.byPlot[forageQualityCensus.plotId] = state.byPlot[forageQualityCensus.plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       alert('Created forageQualityCensus!');
     });
     builder.addCase(getForageQualityCensus.fulfilled, (state, action) => {
       const forageQualityCensus: IForageQualityCensus = action.payload as IForageQualityCensus;
       state.all[forageQualityCensus.id] = forageQualityCensus;
+      if (!state.byPlot[forageQualityCensus.plotId]) {
+        state.byPlot[forageQualityCensus.plotId] = [];
+      }
+      state.byPlot[forageQualityCensus.plotId].push(forageQualityCensus);
+      state.byPlot[forageQualityCensus.plotId] = state.byPlot[forageQualityCensus.plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       alert('Retrieved forageQualityCensus!');
     });
     builder.addCase(updateForageQualityCensus.fulfilled, (state, action) => {
       const forageQualityCensus: IForageQualityCensus = action.payload as IForageQualityCensus;
       state.all[forageQualityCensus.id] = forageQualityCensus;
+      if (!state.byPlot[forageQualityCensus.plotId]) {
+        state.byPlot[forageQualityCensus.plotId] = [];
+      }
+      state.byPlot[forageQualityCensus.plotId].push(forageQualityCensus);
+      state.byPlot[forageQualityCensus.plotId] = state.byPlot[forageQualityCensus.plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       alert('Updated forageQualityCensus!');
     });
     builder.addCase(deleteForageQualityCensus.fulfilled, (state, action) => {
       const forageQualityCensus: IForageQualityCensus = action.payload as IForageQualityCensus;
       delete state.all[forageQualityCensus.id];
+      // TODO: Splice from byPlot
       alert('Deleted forageQualityCensus!');
     });
   },

--- a/src/redux/slices/forageQuantityCensusSlice.ts
+++ b/src/redux/slices/forageQuantityCensusSlice.ts
@@ -15,11 +15,13 @@ export interface IForageQuantityCensus {
 export interface ForageQuantityCensusState {
   loading: boolean
   all: Record<string, IForageQuantityCensus>
+  byPlot: Record<string, IForageQuantityCensus[]>
 }
 
 const initialState: ForageQuantityCensusState = {
   loading: false,
   all: {},
+  byPlot: {},
 };
 
 export const getForageQuantityCensusesByPlotId = createAsyncThunk(
@@ -132,26 +134,49 @@ export const forageQuantityCensusSlice = createSlice({
       const forageQuantityCensuses: IForageQuantityCensus[] = action.payload as IForageQuantityCensus[];
       forageQuantityCensuses.forEach((forageQuantityCensus: IForageQuantityCensus) => {
         state.all[forageQuantityCensus.id] = forageQuantityCensus;
+        if (!state.byPlot[forageQuantityCensus.plotId]) {
+          state.byPlot[forageQuantityCensus.plotId] = [];
+        }
+        state.byPlot[forageQuantityCensus.plotId].push(forageQuantityCensus);
+      });
+      Object.keys(state.byPlot).forEach((plotId: string) => {
+        state.byPlot[plotId] = state.byPlot[plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       });
     });
     builder.addCase(createForageQuantityCensus.fulfilled, (state, action) => {
       const forageQuantityCensus: IForageQuantityCensus = action.payload as IForageQuantityCensus;
       state.all[forageQuantityCensus.id] = forageQuantityCensus;
+      if (!state.byPlot[forageQuantityCensus.plotId]) {
+        state.byPlot[forageQuantityCensus.plotId] = [];
+      }
+      state.byPlot[forageQuantityCensus.plotId].push(forageQuantityCensus);
+      state.byPlot[forageQuantityCensus.plotId] = state.byPlot[forageQuantityCensus.plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       alert('Created forageQuantityCensus!');
     });
     builder.addCase(getForageQuantityCensus.fulfilled, (state, action) => {
       const forageQuantityCensus: IForageQuantityCensus = action.payload as IForageQuantityCensus;
       state.all[forageQuantityCensus.id] = forageQuantityCensus;
+      if (!state.byPlot[forageQuantityCensus.plotId]) {
+        state.byPlot[forageQuantityCensus.plotId] = [];
+      }
+      state.byPlot[forageQuantityCensus.plotId].push(forageQuantityCensus);
+      state.byPlot[forageQuantityCensus.plotId] = state.byPlot[forageQuantityCensus.plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       alert('Retrieved forageQuantityCensus!');
     });
     builder.addCase(updateForageQuantityCensus.fulfilled, (state, action) => {
       const forageQuantityCensus: IForageQuantityCensus = action.payload as IForageQuantityCensus;
       state.all[forageQuantityCensus.id] = forageQuantityCensus;
+      if (!state.byPlot[forageQuantityCensus.plotId]) {
+        state.byPlot[forageQuantityCensus.plotId] = [];
+      }
+      state.byPlot[forageQuantityCensus.plotId].push(forageQuantityCensus);
+      state.byPlot[forageQuantityCensus.plotId] = state.byPlot[forageQuantityCensus.plotId].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
       alert('Updated forageQuantityCensus!');
     });
     builder.addCase(deleteForageQuantityCensus.fulfilled, (state, action) => {
       const forageQuantityCensus: IForageQuantityCensus = action.payload as IForageQuantityCensus;
       delete state.all[forageQuantityCensus.id];
+      // TODO: Splice from byPlot
       alert('Deleted forageQuantityCensus!');
     });
   },

--- a/src/screens/DashboardScreens/FrontPage/index.tsx
+++ b/src/screens/DashboardScreens/FrontPage/index.tsx
@@ -7,71 +7,30 @@ import { logout } from '../../../redux/slices/authSlice';
 import AppButton from '../../../components/AppButton';
 import NavType from '../../../utils/NavType';
 import { ROUTES, DAYS_OF_WEEK } from '../../../utils/constants';
-import { getTeamByUserId, ITeam } from '../../../redux/slices/teamsSlice';
-import { getPlotsByTeamId } from '../../../redux/slices/plotsSlice';
-import { getHerdByTeamId, IHerd } from '../../../redux/slices/herdsSlice';
-import { getCowCensusesByHerdId, ICowCensus } from '../../../redux/slices/cowCensusSlice';
-import { getDungCensusesByHerdId, IDungCensus } from '../../../redux/slices/dungCensusSlice';
-import { getForageQualityCensusesByPlotId } from '../../../redux/slices/forageQualityCensusSlice';
-import { getForageQuantityCensusesByPlotId } from '../../../redux/slices/forageQuantityCensusSlice';
+import { IHerd } from '../../../redux/slices/herdsSlice';
+import { ICowCensus } from '../../../redux/slices/cowCensusSlice';
+import { IDungCensus } from '../../../redux/slices/dungCensusSlice';
+import { IForageQualityCensus } from '../../../redux/slices/forageQualityCensusSlice';
+import { IForageQuantityCensus } from '../../../redux/slices/forageQuantityCensusSlice';
 import { Colors, GlobalStyle } from '../../../styles';
 import { LivestockStatusCard, PaddockStatusCard } from '../../../components/Dashboard';
 import DashboardStyle from '../../../styles/pages/DashboardStyle';
 import average from '../../../utils/average';
 import { diffDays } from '../../../utils/dateUtil';
 
-
 const FrontPage = () => {
   const navigation = useNavigation<NavType>();
   const dispatch = useAppDispatch();
 
-  const { id } = useAppSelector((state) => state.auth); // userId
-  const selectedTeam: ITeam = useAppSelector((state) => state.teams.selectedTeam);
   const { allPlots } = useAppSelector((state) => state.plots);
-  const selectedHerd: IHerd = useAppSelector((state) => state.herds.selectedHerd);
   const { name } = useAppSelector((state) => state.auth);
+  const selectedHerd: IHerd = useAppSelector((state) => state.herds.selectedHerd);
   const latestCowCensus: ICowCensus = useAppSelector((state) => state.cowCensuses.indices.latest);
   const latestDungCensus: IDungCensus = useAppSelector((state) => state.dungCensuses.indices.latest);
+  const forageQualityByPlot: Record<string, IForageQualityCensus[]> = useAppSelector((state) => state.forageQuality.byPlot);
+  const forageQuantityByPlot: Record<string, IForageQuantityCensus[]> = useAppSelector((state) => state.forageQuantity.byPlot);
 
   const [isOpenGraph, setIsOpenGraph] = useState<boolean>(false);
-
-  useEffect(() => {
-    dispatch(getTeamByUserId({ userId: id }));
-  }, []);
-  useEffect(() => {
-    if (selectedTeam) {
-      dispatch(getHerdByTeamId({ teamId: selectedTeam?.id as string }));
-    }
-  }, [selectedTeam]);
-  useEffect(() => {
-    if (allPlots) {
-      dispatch(getPlotsByTeamId({ teamId: selectedTeam?.id as string }));
-    }
-  }, [selectedTeam]);
-  useEffect(() => {
-    if (selectedHerd) {
-      dispatch(getCowCensusesByHerdId({ herdId: selectedHerd?.id as string }));
-    }
-  }, [selectedHerd]);
-  useEffect(() => {
-    if (selectedHerd) {
-      dispatch(getDungCensusesByHerdId({ herdId: selectedHerd?.id as string }));
-    }
-  }, [selectedHerd]);
-  useEffect(() => {
-    if (allPlots) {
-      Object.keys(allPlots).forEach((plotId: string) => {
-        dispatch(getForageQualityCensusesByPlotId({ plotId }));
-      });
-    }
-  }, [allPlots]);
-  useEffect(() => {
-    if (allPlots) {
-      Object.keys(allPlots).forEach((plotId: string) => {
-        dispatch(getForageQuantityCensusesByPlotId({ plotId }));
-      });
-    }
-  }, [allPlots]);
 
   return (
     <SafeAreaView style={GlobalStyle.container}>
@@ -95,7 +54,7 @@ const FrontPage = () => {
               {/* Cow Image */}
               <Image source={require('../../../assets/cow1.png')} />
               <View>
-                <Text style={DashboardStyle.critDays}>{diffDays(new Date(), new Date())} days</Text>
+                <Text style={DashboardStyle.critDays}>{diffDays(new Date(selectedHerd.calvingDate), new Date())} days</Text>
                 <Text style={DashboardStyle.critText}>to calving</Text>
               </View>
             </View>
@@ -104,7 +63,7 @@ const FrontPage = () => {
               {/* Cow Image */}
               <Image source={require('../../../assets/cow2.png')} />
               <View>
-                <Text style={DashboardStyle.critDays}>{diffDays(new Date(), new Date())} days</Text>
+                <Text style={DashboardStyle.critDays}>{diffDays(new Date(selectedHerd.breedingDate), new Date())} days</Text>
                 <Text style={DashboardStyle.critText}>to breeding</Text>
               </View>
             </View>
@@ -120,7 +79,7 @@ const FrontPage = () => {
               />
               <LivestockStatusCard
                 type='dung'
-                score={average(latestDungCensus?.ratings)}
+                score={+average(latestDungCensus?.ratings).toFixed(1)}
               />
             </View>
 
@@ -157,14 +116,14 @@ const FrontPage = () => {
             contentContainerStyle={DashboardStyle.cardLayout}
           >
             {
-              allPlots && (
+              allPlots && forageQualityByPlot && forageQuantityByPlot && (
                 Object.keys(allPlots).map((plotId, idx) => {
                   return (
                     <PaddockStatusCard
                       key={idx}
                       title={allPlots[plotId].name}
-                      forage={0} // TBD
-                      days={0} // TBD
+                      forage={forageQualityByPlot[plotId] ? forageQualityByPlot[plotId][0].rating : 0}
+                      days={forageQuantityByPlot[plotId] ? forageQuantityByPlot[plotId][0].sda : 0}
                     />
                   );
                 })

--- a/src/screens/DashboardScreens/LoadingPage/index.tsx
+++ b/src/screens/DashboardScreens/LoadingPage/index.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { Image, ScrollView, View, SafeAreaView, Dimensions, Text } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import useAppSelector from '../../../hooks/useAppSelector';
+import useAppDispatch from '../../../hooks/useAppDispatch';
+import NavType from '../../../utils/NavType';
+import { loadData } from '../../../redux/slices/syncSlice';
+import { Colors, GlobalStyle } from '../../../styles';
+
+const LoadingPage = () => {
+  const dispatch = useAppDispatch();
+  const userId: string = useAppSelector((state) => state.auth.id); // userId
+
+  useEffect(() => {
+    dispatch(loadData(userId));
+  }, []);
+
+  return (
+    <SafeAreaView style={GlobalStyle.container}>
+      <ScrollView
+        contentContainerStyle={GlobalStyle.contentContainerScroll}
+      >
+        <Text>Loading...</Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default LoadingPage;

--- a/src/screens/DashboardScreens/index.tsx
+++ b/src/screens/DashboardScreens/index.tsx
@@ -1,7 +1,9 @@
 import FrontPage from './FrontPage';
 import FormRootPage from './FormRootPage';
+import LoadingPage from './LoadingPage';
 
 export {
   FrontPage,
   FormRootPage,
+  LoadingPage,
 };

--- a/src/screens/index.jsx
+++ b/src/screens/index.jsx
@@ -13,6 +13,7 @@ import {
 import {
   FrontPage,
   FormRootPage,
+  LoadingPage,
 } from './DashboardScreens';
 import {
   AboutStacPage,
@@ -42,6 +43,7 @@ export {
   JoinTeamPage,
   FrontPage,
   FormRootPage,
+  LoadingPage,
   AboutStacPage,
   BCSPage,
   DungPage,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,6 @@
 // With Expo Go, SERVER_URL needs to be exact IPv4 Address
-export const SERVER_URL = 'https://grazing-earth-backend.onrender.com/';
-// export const SERVER_URL = 'http://10.135.149.198:4000/';
+// export const SERVER_URL = 'https://grazing-earth-backend.onrender.com/';
+export const SERVER_URL = 'http://192.168.1.7:4000/';
 
 export const ROUTES = {
   AUTHLAUNCH: 'Welcome',
@@ -12,6 +12,8 @@ export const ROUTES = {
 
   USERS: 'Users',
   RESOURCES: 'Resources',
+
+  LOADING_PAGE: 'Loading',
 
   HOME: 'Front Page',
 

--- a/src/utils/dateUtil.tsx
+++ b/src/utils/dateUtil.tsx
@@ -1,6 +1,3 @@
 export function diffDays(d1: Date, d2: Date) {
-  if (!d1 || !d2) return 0;
-  if (!d2.getDay()) return 0;
-  
-  return ((d1.getDay() - d2.getDay() % 365) + 365) % 365;
+  return ((Math.ceil(Math.abs(d1.getTime() - d2.getTime()) / (1000 * 3600 * 24)) % 365) + 365) % 365;
 }


### PR DESCRIPTION
# fix fetching resync; connect values to store

- Flow for fetching information upon login is, for the most part, cleaner.
- Hook displayed values on front page to store

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Screenshots
![img](https://i.imgur.com/9Q73Trm_d.webp?maxwidth=640&shape=thumb&fidelity=medium)

## TODO
- Could utilize less callbacks still on the fetching information upon login. But this would require some reshaping of the backend as well (namely, putting teamId as a foreign key on everything)
